### PR TITLE
Compatible build for kubernetes/ingress 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifndef COMMIT
   COMMIT := git-$(shell git rev-parse --short HEAD)
 endif
 
-PKG=git.nwaonline.com/kubernetes/caddy-ingress
+PKG=github.com/wehco/caddy-ingress-controller
 
 build: clean
 	CGO_ENABLED=0 GOOS=${GOOS} go build -a -installsuffix cgo \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ ifndef COMMIT
   COMMIT := git-$(shell git rev-parse --short HEAD)
 endif
 
-PKG=github.com/wehco/caddy-ingress-controller
+#PKG=github.com/wehco/caddy-ingress-controller
+PKG=k8s.io/ingress/controllers/caddy
 
 build: clean
 	CGO_ENABLED=0 GOOS=${GOOS} go build -a -installsuffix cgo \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ ifndef COMMIT
   COMMIT := git-$(shell git rev-parse --short HEAD)
 endif
 
-#PKG=github.com/wehco/caddy-ingress-controller
 PKG=k8s.io/ingress/controllers/caddy
 
 build: clean

--- a/pkg/cmd/controller/caddy.go
+++ b/pkg/cmd/controller/caddy.go
@@ -22,7 +22,7 @@ import (
 	cdy_template "k8s.io/ingress/controllers/caddy/pkg/template"
 	"k8s.io/ingress/controllers/caddy/pkg/version"
 
-  api "k8s.io/api/core/v1"
+  api "k8s.io/client-go/pkg/api/v1"
 
 	"k8s.io/ingress/core/pkg/ingress"
 	"k8s.io/ingress/core/pkg/ingress/defaults"
@@ -252,7 +252,7 @@ func (c *CaddyController) OnUpdate(ingressCfg ingress.Configuration) error {
 	cfg := cdy_template.ReadConfig(c.configmap.Data)
 	cfg.Resolver = c.resolver
 
-	content, err := c.t.Write(config.TemplateConfig{
+	_, err := c.t.Write(config.TemplateConfig{
 		Backends:    ingressCfg.Backends,
 		Servers:     ingressCfg.Servers,
 		TCPBackends: ingressCfg.TCPEndpoints,

--- a/pkg/cmd/controller/caddy.go
+++ b/pkg/cmd/controller/caddy.go
@@ -22,7 +22,7 @@ import (
 	cdy_template "github.com/wehco/caddy-ingress-controller/pkg/template"
 	"github.com/wehco/caddy-ingress-controller/pkg/version"
 
-	api "k8s.io/client-go/pkg/api/v1"
+  api "k8s.io/api/core/v1"
 
 	"k8s.io/ingress/core/pkg/ingress"
 	"k8s.io/ingress/core/pkg/ingress/defaults"

--- a/pkg/cmd/controller/caddy.go
+++ b/pkg/cmd/controller/caddy.go
@@ -248,7 +248,7 @@ func (c CaddyController) SetListers(lister ingress.StoreLister) {
 // write the configuration file
 // returning nil implies the backend will be reloaded
 // if an error is returned the update should be re-queued
-func (c *CaddyController) OnUpdate(ingressCfg ingress.Configuration) ([]byte, error) {
+func (c *CaddyController) OnUpdate(ingressCfg ingress.Configuration) error {
 	cfg := cdy_template.ReadConfig(c.configmap.Data)
 	cfg.Resolver = c.resolver
 
@@ -263,14 +263,14 @@ func (c *CaddyController) OnUpdate(ingressCfg ingress.Configuration) ([]byte, er
 		Cfg:         cfg,
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// TODO: Validate config template results
 
 	ingressCfgJson, _ = json.Marshal(ingressCfg)
 
-	return content, nil
+	return nil
 }
 
 // == HealthCheck ==

--- a/pkg/cmd/controller/caddy.go
+++ b/pkg/cmd/controller/caddy.go
@@ -22,7 +22,7 @@ import (
 	cdy_template "k8s.io/ingress/controllers/caddy/pkg/template"
 	"k8s.io/ingress/controllers/caddy/pkg/version"
 
-  api "k8s.io/client-go/pkg/api/v1"
+	api "k8s.io/client-go/pkg/api/v1"
 
 	"k8s.io/ingress/core/pkg/ingress"
 	"k8s.io/ingress/core/pkg/ingress/defaults"

--- a/pkg/cmd/controller/caddy.go
+++ b/pkg/cmd/controller/caddy.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"git.nwaonline.com/kubernetes/caddy-ingress/pkg/config"
-	cdy_template "git.nwaonline.com/kubernetes/caddy-ingress/pkg/template"
-	"git.nwaonline.com/kubernetes/caddy-ingress/pkg/version"
+	"github.com/wehco/caddy-ingress-controller/pkg/config"
+	cdy_template "github.com/wehco/caddy-ingress-controller/pkg/template"
+	"github.com/wehco/caddy-ingress-controller/pkg/version"
 
 	api "k8s.io/client-go/pkg/api/v1"
 

--- a/pkg/cmd/controller/caddy.go
+++ b/pkg/cmd/controller/caddy.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/wehco/caddy-ingress-controller/pkg/config"
-	cdy_template "github.com/wehco/caddy-ingress-controller/pkg/template"
-	"github.com/wehco/caddy-ingress-controller/pkg/version"
+	"k8s.io/ingress/controllers/caddy/pkg/config"
+	cdy_template "k8s.io/ingress/controllers/caddy/pkg/template"
+	"k8s.io/ingress/controllers/caddy/pkg/version"
 
   api "k8s.io/api/core/v1"
 
@@ -204,6 +204,9 @@ func (c CaddyController) Info() *ingress.BackendInfo {
 		Build:      version.COMMIT,
 		Repository: version.REPO,
 	}
+}
+
+func (c *CaddyController) ConfigureFlags(flags *pflag.FlagSet) {
 }
 
 func (c CaddyController) OverrideFlags(flags *pflag.FlagSet) {

--- a/pkg/template/configmap.go
+++ b/pkg/template/configmap.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/wehco/caddy-ingress-controller/pkg/config"
+	"k8s.io/ingress/controllers/caddy/pkg/config"
 )
 
 // ReadConfig obtains the configuration defined by the user merged with the defaults.

--- a/pkg/template/configmap.go
+++ b/pkg/template/configmap.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 
-	"git.nwaonline.com/kubernetes/caddy-ingress/pkg/config"
+	"github.com/wehco/caddy-ingress-controller/pkg/config"
 )
 
 // ReadConfig obtains the configuration defined by the user merged with the defaults.

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	text_template "text/template"
 
-	"github.com/wehco/caddy-ingress-controller/pkg/config"
+	"k8s.io/ingress/controllers/caddy/pkg/config"
 
 	"k8s.io/ingress/core/pkg/watch"
 )

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	text_template "text/template"
 
-	"git.nwaonline.com/kubernetes/caddy-ingress/pkg/config"
+	"github.com/wehco/caddy-ingress-controller/pkg/config"
 
 	"k8s.io/ingress/core/pkg/watch"
 )


### PR DESCRIPTION
Hello,

I was having trouble building per the instructions in the README, first due to package conflicts  with git.nwaonline.com/kubernetes/caddy-ingress, then with various compilation errors due to updates in the kubernetes ingress code & vendor packages. 

I have resolved those issues, and updated some interfaces that changed since your last commit. However, the package must be built under the k8s.io namespace for compatibilty with the vendor libraries.